### PR TITLE
Don't create redirects from and to identical slugs

### DIFF
--- a/src/utils/updateSlugRedirects.ts
+++ b/src/utils/updateSlugRedirects.ts
@@ -7,6 +7,10 @@ export default async function updateSlugRedirects(
   recordID: string,
   client: Client
 ) {
+  if (oldSlug === newSlug) {
+    return;
+  }
+
   const newObject = {
     source: oldSlug,
     destination: newSlug,


### PR DESCRIPTION
We've been having issues with DatoCMS thinking that slug fields have been updated when their content hasn't changed, and ending up with redirects from/to identical slugs which can wreak havoc downstream in website builds. 

Users can obviously guard against this in their build pipelines, but the plugin should really guard for it in the first place.